### PR TITLE
Remove scipy from windows build environment

### DIFF
--- a/ci/requirements-windows.yml
+++ b/ci/requirements-windows.yml
@@ -5,5 +5,4 @@ dependencies:
   - pip
   - pytest
   - numpy
-  - scipy # shouldn't be here but build fails on github actions for Windows / Python >= 3.8 https://github.com/brian-rose/climlab-rrtmg/pull/5
   - flang


### PR DESCRIPTION
Trying this as a potential fix for #11, based on weirdness discussed back in #5