### PR TITLE
Create pydistutils.cfg

### DIFF
--- a/pydistutils.cfg
+++ b/pydistutils.cfg
@@ -1,0 +1,2 @@
+[build]
+compiler=mingw32


### PR DESCRIPTION
Following some advice [here](http://docs.solcore.solar/en/master/Installation/compilation.html), it seems like this file might be needed to configure the Windows compiler