### PR TITLE
Support variable solar irradiance factor

### DIFF
--- a/climlab_rrtmg/rrtmg_sw/Driver.f90
+++ b/climlab_rrtmg/rrtmg_sw/Driver.f90
@@ -238,7 +238,7 @@ subroutine climlab_rrtmg_sw &
 !  These are not comments! Necessary directives to f2py to handle array dimensions
 !f2py depend(ncol,nlay) play, plev, tlay, tlev
 !f2py depend(ncol,nlay) h2ovmr,o3vmr,co2vmr,ch4vmr,n2ovmr,o2vmr
-!f2py depend(ncol) tsfc, aldif, aldir, asdif, asdir, coszen
+!f2py depend(ncol) tsfc, aldif, aldir, asdif, asdir, coszen, adjes
 !f2py depend(ncol,nlay) tauaer,ssaaer,asmaer,ecaer
 !f2py depend(ncol,nlay) reicmcl,relqmcl
 !f2py depend(ncol,nlay) cldfmcl,ciwpmcl,clwpmcl,taucmcl,ssacmcl,asmcmcl,fsfcmcl

--- a/climlab_rrtmg/rrtmg_sw/Driver.f90
+++ b/climlab_rrtmg/rrtmg_sw/Driver.f90
@@ -147,7 +147,7 @@ subroutine climlab_rrtmg_sw &
     real(kind=rb), intent(in) :: asdif(ncol)        ! UV/vis surface albedo: diffuse rad
     real(kind=rb), intent(in) :: asdir(ncol)        ! Near-IR surface albedo: diffuse rad
     real(kind=rb), intent(in) :: coszen(ncol)       ! Cosine of solar zenith angle
-    real(kind=rb), intent(in) :: adjes              ! Flux adjustment for Earth/Sun distance
+    real(kind=rb), intent(in) :: adjes(ncol)        ! Flux adjustment (Earth/Sun distance and/or zenith angle compensation)
     integer(kind=im), intent(in) :: dyofyr          ! Day of the year (used to get Earth/Sun
                                                     !  distance if adjflx not provided)
     real(kind=rb), intent(in) :: scon               ! Solar constant (W/m2)

--- a/climlab_rrtmg/rrtmg_sw/_rrtmg_sw.pyf
+++ b/climlab_rrtmg/rrtmg_sw/_rrtmg_sw.pyf
@@ -5,430 +5,430 @@ python module _rrtmg_sw ! in
     interface  ! in :_rrtmg_sw
         module parrrsw ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/parrrsw.f90
             use parkind, only: im=>kind_im,rb=>kind_rb
-            integer(kind=im), parameter,optional :: jmumu=32
             integer(kind=im), parameter,optional :: mxlay=203
-            integer(kind=im), parameter,optional :: jpb1=16
-            integer(kind=im), parameter,optional :: jmxstr=16
-            integer(kind=im), parameter,optional :: jpb2=29
-            integer(kind=im), parameter,optional :: naerec=6
-            integer(kind=im), parameter,optional :: jmcmu=32
-            integer(kind=im), parameter,optional :: jmphi=3
-            integer(kind=im), parameter,optional :: ng29=12
-            integer(kind=im), parameter,optional :: ng28=6
-            integer(kind=im), parameter,optional :: ng23=10
-            integer(kind=im), parameter,optional :: ng22=2
-            integer(kind=im), parameter,optional :: ng21=10
-            integer(kind=im), parameter,optional :: ng20=10
-            integer(kind=im), parameter,optional :: ng27=8
-            integer(kind=im), parameter,optional :: ng26=6
-            integer(kind=im), parameter,optional :: ng25=6
-            integer(kind=im), parameter,optional :: ng24=8
+            integer(kind=im), parameter,optional :: mg=16
             integer(kind=im), parameter,optional :: nbndsw=14
-            integer(kind=im), parameter,optional :: ngs29=112
-            integer(kind=im), parameter,optional :: ngs28=100
-            integer(kind=im), parameter,optional :: ngs27=94
-            integer(kind=im), parameter,optional :: jmxang=4
-            integer(kind=im), parameter,optional :: ngs25=80
-            integer(kind=im), parameter,optional :: ngs24=74
-            integer(kind=im), parameter,optional :: ngs23=66
-            integer(kind=im), parameter,optional :: ngs22=56
-            integer(kind=im), parameter,optional :: ngs21=54
-            integer(kind=im), parameter,optional :: ngs20=44
+            integer(kind=im), parameter,optional :: naerec=6
             integer(kind=im), parameter,optional :: mxmol=38
+            integer(kind=im), parameter,optional :: nstr=2
+            integer(kind=im), parameter,optional :: nmol=7
+            integer(kind=im), parameter,optional :: ngptsw=112
+            integer(kind=im), parameter,optional :: jpband=29
+            integer(kind=im), parameter,optional :: jpb1=16
+            integer(kind=im), parameter,optional :: jpb2=29
+            integer(kind=im), parameter,optional :: jmcmu=32
+            integer(kind=im), parameter,optional :: jmumu=32
+            integer(kind=im), parameter,optional :: jmphi=3
+            integer(kind=im), parameter,optional :: jmxang=4
+            integer(kind=im), parameter,optional :: jmxstr=16
             integer(kind=im), parameter,optional :: ng16=6
             integer(kind=im), parameter,optional :: ng17=12
-            integer(kind=im), parameter,optional :: ngs26=86
             integer(kind=im), parameter,optional :: ng18=8
             integer(kind=im), parameter,optional :: ng19=8
-            integer(kind=im), parameter,optional :: mg=16
-            real(kind=rb), parameter,optional :: rrsw_scon=1368.22
-            integer(kind=im), parameter,optional :: nmol=7
-            integer(kind=im), parameter,optional :: nstr=2
-            integer(kind=im), parameter,optional :: jpband=29
-            integer(kind=im), parameter,optional :: ngptsw=112
+            integer(kind=im), parameter,optional :: ng20=10
+            integer(kind=im), parameter,optional :: ng21=10
+            integer(kind=im), parameter,optional :: ng22=2
+            integer(kind=im), parameter,optional :: ng23=10
+            integer(kind=im), parameter,optional :: ng24=8
+            integer(kind=im), parameter,optional :: ng25=6
+            integer(kind=im), parameter,optional :: ng26=6
+            integer(kind=im), parameter,optional :: ng27=8
+            integer(kind=im), parameter,optional :: ng28=6
+            integer(kind=im), parameter,optional :: ng29=12
             integer(kind=im), parameter,optional :: ngs16=6
             integer(kind=im), parameter,optional :: ngs17=18
             integer(kind=im), parameter,optional :: ngs18=26
             integer(kind=im), parameter,optional :: ngs19=34
+            integer(kind=im), parameter,optional :: ngs20=44
+            integer(kind=im), parameter,optional :: ngs21=54
+            integer(kind=im), parameter,optional :: ngs22=56
+            integer(kind=im), parameter,optional :: ngs23=66
+            integer(kind=im), parameter,optional :: ngs24=74
+            integer(kind=im), parameter,optional :: ngs25=80
+            integer(kind=im), parameter,optional :: ngs26=86
+            integer(kind=im), parameter,optional :: ngs27=94
+            integer(kind=im), parameter,optional :: ngs28=100
+            integer(kind=im), parameter,optional :: ngs29=112
+            real(kind=rb), parameter,optional :: rrsw_scon=1368.22
         end module parrrsw
         module rrsw_kg16 ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg16.f90
-            use parrrsw, only: ng16
             use parkind, only: im=>kind_im,rb=>kind_rb
-            real(kind=rb) dimension(16) :: snsptdrko
-            real(kind=rb) dimension(5,47,16) :: kbo
-            real(kind=rb) dimension(10,6) :: selfref
-            real(kind=rb) dimension(16) :: sfluxrefo
-            real(kind=rb) dimension(9,5,13,16) :: kao
-            real(kind=rb) dimension(235,6) :: absb
-            real(kind=rb) dimension(6) :: irradnce
-            real(kind=rb) dimension(5,47,6) :: kb
-            real(kind=rb) dimension(9,5,13,6) :: ka
-            real(kind=rb) dimension(10,16) :: selfrefo
-            real(kind=rb) dimension(16) :: facbrghto
+            use parrrsw, only: ng16
             integer(kind=im), parameter,optional :: no16=16
-            real(kind=rb) dimension(6) :: sfluxref
-            real(kind=rb) dimension(16) :: irradnceo
-            real(kind=rb) dimension(585,6) :: absa
-            real(kind=rb) dimension(3,6) :: forref
-            real(kind=rb) dimension(6) :: facbrght
+            real(kind=rb) dimension(9,5,13,16) :: kao
+            real(kind=rb) dimension(5,47,16) :: kbo
+            real(kind=rb) dimension(10,16) :: selfrefo
             real(kind=rb) dimension(3,16) :: forrefo
+            real(kind=rb) dimension(16) :: sfluxrefo
+            real(kind=rb) dimension(16) :: irradnceo
+            real(kind=rb) dimension(16) :: facbrghto
+            real(kind=rb) dimension(16) :: snsptdrko
             real(kind=rb) :: rayl
+            real(kind=rb) dimension(9,5,13,6) :: ka
+            real(kind=rb) dimension(585,6) :: absa
+            real(kind=rb) dimension(5,47,6) :: kb
+            real(kind=rb) dimension(235,6) :: absb
+            real(kind=rb) dimension(10,6) :: selfref
+            real(kind=rb) dimension(3,6) :: forref
+            real(kind=rb) dimension(6) :: sfluxref
+            real(kind=rb) dimension(6) :: irradnce
+            real(kind=rb) dimension(6) :: facbrght
             real(kind=rb) dimension(6) :: snsptdrk
         end module rrsw_kg16
         module rrsw_kg17 ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg17.f90
-            use parrrsw, only: ng17
             use parkind, only: im=>kind_im,rb=>kind_rb
-            real(kind=rb) dimension(16,5) :: snsptdrko
-            real(kind=rb) dimension(5,5,47,16) :: kbo
-            real(kind=rb) dimension(10,12) :: selfref
-            real(kind=rb) dimension(12,5) :: facbrght
-            real(kind=rb) dimension(9,5,13,16) :: kao
-            real(kind=rb) dimension(1175,12) :: absb
-            real(kind=rb) dimension(12,5) :: irradnce
-            real(kind=rb) dimension(5,5,47,12) :: kb
-            real(kind=rb) dimension(9,5,13,12) :: ka
-            real(kind=rb) dimension(10,16) :: selfrefo
-            real(kind=rb) dimension(16,5) :: facbrghto
+            use parrrsw, only: ng17
             integer(kind=im), parameter,optional :: no17=16
-            real(kind=rb) dimension(12,5) :: sfluxref
-            real(kind=rb) dimension(16,5) :: irradnceo
-            real(kind=rb) dimension(585,12) :: absa
-            real(kind=rb) dimension(4,12) :: forref
-            real(kind=rb) dimension(16,5) :: sfluxrefo
+            real(kind=rb) dimension(9,5,13,16) :: kao
+            real(kind=rb) dimension(5,5,47,16) :: kbo
+            real(kind=rb) dimension(10,16) :: selfrefo
             real(kind=rb) dimension(4,16) :: forrefo
+            real(kind=rb) dimension(16,5) :: sfluxrefo
+            real(kind=rb) dimension(16,5) :: irradnceo
+            real(kind=rb) dimension(16,5) :: facbrghto
+            real(kind=rb) dimension(16,5) :: snsptdrko
             real(kind=rb) :: rayl
+            real(kind=rb) dimension(9,5,13,12) :: ka
+            real(kind=rb) dimension(585,12) :: absa
+            real(kind=rb) dimension(5,5,47,12) :: kb
+            real(kind=rb) dimension(1175,12) :: absb
+            real(kind=rb) dimension(10,12) :: selfref
+            real(kind=rb) dimension(4,12) :: forref
+            real(kind=rb) dimension(12,5) :: sfluxref
+            real(kind=rb) dimension(12,5) :: irradnce
+            real(kind=rb) dimension(12,5) :: facbrght
             real(kind=rb) dimension(12,5) :: snsptdrk
         end module rrsw_kg17
         module rrsw_kg18 ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg18.f90
-            use parrrsw, only: ng18
             use parkind, only: im=>kind_im,rb=>kind_rb
-            real(kind=rb) dimension(16,9) :: snsptdrko
-            real(kind=rb) dimension(5,47,16) :: kbo
-            real(kind=rb) dimension(10,8) :: selfref
-            real(kind=rb) dimension(16,9) :: sfluxrefo
-            real(kind=rb) dimension(9,5,13,16) :: kao
-            real(kind=rb) dimension(235,8) :: absb
-            real(kind=rb) dimension(8,9) :: irradnce
-            real(kind=rb) dimension(5,47,8) :: kb
-            real(kind=rb) dimension(9,5,13,8) :: ka
-            real(kind=rb) dimension(10,16) :: selfrefo
-            real(kind=rb) dimension(16,9) :: facbrghto
+            use parrrsw, only: ng18
             integer(kind=im), parameter,optional :: no18=16
-            real(kind=rb) dimension(8,9) :: sfluxref
-            real(kind=rb) dimension(16,9) :: irradnceo
-            real(kind=rb) dimension(585,8) :: absa
-            real(kind=rb) dimension(3,8) :: forref
-            real(kind=rb) dimension(8,9) :: facbrght
+            real(kind=rb) dimension(9,5,13,16) :: kao
+            real(kind=rb) dimension(5,47,16) :: kbo
+            real(kind=rb) dimension(10,16) :: selfrefo
             real(kind=rb) dimension(3,16) :: forrefo
+            real(kind=rb) dimension(16,9) :: sfluxrefo
+            real(kind=rb) dimension(16,9) :: irradnceo
+            real(kind=rb) dimension(16,9) :: facbrghto
+            real(kind=rb) dimension(16,9) :: snsptdrko
             real(kind=rb) :: rayl
+            real(kind=rb) dimension(9,5,13,8) :: ka
+            real(kind=rb) dimension(585,8) :: absa
+            real(kind=rb) dimension(5,47,8) :: kb
+            real(kind=rb) dimension(235,8) :: absb
+            real(kind=rb) dimension(10,8) :: selfref
+            real(kind=rb) dimension(3,8) :: forref
+            real(kind=rb) dimension(8,9) :: sfluxref
+            real(kind=rb) dimension(8,9) :: irradnce
+            real(kind=rb) dimension(8,9) :: facbrght
             real(kind=rb) dimension(8,9) :: snsptdrk
         end module rrsw_kg18
         module rrsw_kg19 ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg19.f90
-            use parrrsw, only: ng19
             use parkind, only: im=>kind_im,rb=>kind_rb
-            real(kind=rb) dimension(16,9) :: snsptdrko
-            real(kind=rb) dimension(5,47,16) :: kbo
-            real(kind=rb) dimension(10,8) :: selfref
-            real(kind=rb) dimension(16,9) :: sfluxrefo
-            real(kind=rb) dimension(9,5,13,16) :: kao
-            real(kind=rb) dimension(235,8) :: absb
-            real(kind=rb) dimension(8,9) :: irradnce
-            real(kind=rb) dimension(5,47,8) :: kb
-            real(kind=rb) dimension(9,5,13,8) :: ka
-            real(kind=rb) dimension(10,16) :: selfrefo
-            real(kind=rb) dimension(16,9) :: facbrghto
+            use parrrsw, only: ng19
             integer(kind=im), parameter,optional :: no19=16
-            real(kind=rb) dimension(8,9) :: sfluxref
-            real(kind=rb) dimension(16,9) :: irradnceo
-            real(kind=rb) dimension(585,8) :: absa
-            real(kind=rb) dimension(3,8) :: forref
-            real(kind=rb) dimension(8,9) :: facbrght
+            real(kind=rb) dimension(9,5,13,16) :: kao
+            real(kind=rb) dimension(5,47,16) :: kbo
+            real(kind=rb) dimension(10,16) :: selfrefo
             real(kind=rb) dimension(3,16) :: forrefo
+            real(kind=rb) dimension(16,9) :: sfluxrefo
+            real(kind=rb) dimension(16,9) :: irradnceo
+            real(kind=rb) dimension(16,9) :: facbrghto
+            real(kind=rb) dimension(16,9) :: snsptdrko
             real(kind=rb) :: rayl
+            real(kind=rb) dimension(9,5,13,8) :: ka
+            real(kind=rb) dimension(585,8) :: absa
+            real(kind=rb) dimension(5,47,8) :: kb
+            real(kind=rb) dimension(235,8) :: absb
+            real(kind=rb) dimension(10,8) :: selfref
+            real(kind=rb) dimension(3,8) :: forref
+            real(kind=rb) dimension(8,9) :: sfluxref
+            real(kind=rb) dimension(8,9) :: irradnce
+            real(kind=rb) dimension(8,9) :: facbrght
             real(kind=rb) dimension(8,9) :: snsptdrk
         end module rrsw_kg19
         module rrsw_kg20 ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg20.f90
-            use parrrsw, only: ng20
             use parkind, only: im=>kind_im,rb=>kind_rb
-            real(kind=rb) dimension(16) :: snsptdrko
-            real(kind=rb) dimension(5,47,16) :: kbo
-            real(kind=rb) dimension(10,10) :: selfref
-            real(kind=rb) dimension(5,47,10) :: kb
-            real(kind=rb) dimension(16) :: sfluxrefo
-            real(kind=rb) dimension(5,13,16) :: kao
-            real(kind=rb) dimension(4,10) :: forref
-            real(kind=rb) dimension(10) :: irradnce
-            real(kind=rb) dimension(16) :: absch4o
-            real(kind=rb) dimension(10) :: absch4
-            real(kind=rb) dimension(5,13,10) :: ka
+            use parrrsw, only: ng20
             integer(kind=im), parameter,optional :: no20=16
+            real(kind=rb) dimension(5,13,16) :: kao
+            real(kind=rb) dimension(5,47,16) :: kbo
             real(kind=rb) dimension(10,16) :: selfrefo
-            real(kind=rb) dimension(16) :: facbrghto
-            real(kind=rb) dimension(10) :: sfluxref
-            real(kind=rb) dimension(16) :: irradnceo
-            real(kind=rb) dimension(65,10) :: absa
-            real(kind=rb) dimension(235,10) :: absb
-            real(kind=rb) dimension(10) :: facbrght
             real(kind=rb) dimension(4,16) :: forrefo
+            real(kind=rb) dimension(16) :: sfluxrefo
+            real(kind=rb) dimension(16) :: irradnceo
+            real(kind=rb) dimension(16) :: facbrghto
+            real(kind=rb) dimension(16) :: snsptdrko
+            real(kind=rb) dimension(16) :: absch4o
             real(kind=rb) :: rayl
+            real(kind=rb) dimension(5,13,10) :: ka
+            real(kind=rb) dimension(65,10) :: absa
+            real(kind=rb) dimension(5,47,10) :: kb
+            real(kind=rb) dimension(235,10) :: absb
+            real(kind=rb) dimension(10,10) :: selfref
+            real(kind=rb) dimension(4,10) :: forref
+            real(kind=rb) dimension(10) :: sfluxref
+            real(kind=rb) dimension(10) :: irradnce
+            real(kind=rb) dimension(10) :: facbrght
             real(kind=rb) dimension(10) :: snsptdrk
+            real(kind=rb) dimension(10) :: absch4
         end module rrsw_kg20
         module rrsw_kg21 ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg21.f90
-            use parrrsw, only: ng21
             use parkind, only: im=>kind_im,rb=>kind_rb
-            real(kind=rb) dimension(1175,10) :: absb
-            real(kind=rb) dimension(16,9) :: snsptdrko
-            real(kind=rb) dimension(5,5,47,16) :: kbo
-            real(kind=rb) dimension(10,10) :: selfref
-            real(kind=rb) dimension(16,9) :: sfluxrefo
-            real(kind=rb) dimension(9,5,13,16) :: kao
-            real(kind=rb) dimension(9,5,13,10) :: ka
-            real(kind=rb) dimension(10,9) :: irradnce
-            real(kind=rb) dimension(5,5,47,10) :: kb
+            use parrrsw, only: ng21
             integer(kind=im), parameter,optional :: no21=16
+            real(kind=rb) dimension(9,5,13,16) :: kao
+            real(kind=rb) dimension(5,5,47,16) :: kbo
             real(kind=rb) dimension(10,16) :: selfrefo
-            real(kind=rb) dimension(16,9) :: facbrghto
-            real(kind=rb) dimension(10,9) :: sfluxref
-            real(kind=rb) dimension(16,9) :: irradnceo
-            real(kind=rb) dimension(585,10) :: absa
-            real(kind=rb) dimension(4,10) :: forref
-            real(kind=rb) dimension(10,9) :: facbrght
             real(kind=rb) dimension(4,16) :: forrefo
+            real(kind=rb) dimension(16,9) :: sfluxrefo
+            real(kind=rb) dimension(16,9) :: irradnceo
+            real(kind=rb) dimension(16,9) :: facbrghto
+            real(kind=rb) dimension(16,9) :: snsptdrko
             real(kind=rb) :: rayl
+            real(kind=rb) dimension(9,5,13,10) :: ka
+            real(kind=rb) dimension(585,10) :: absa
+            real(kind=rb) dimension(5,5,47,10) :: kb
+            real(kind=rb) dimension(1175,10) :: absb
+            real(kind=rb) dimension(10,10) :: selfref
+            real(kind=rb) dimension(4,10) :: forref
+            real(kind=rb) dimension(10,9) :: sfluxref
+            real(kind=rb) dimension(10,9) :: irradnce
+            real(kind=rb) dimension(10,9) :: facbrght
             real(kind=rb) dimension(10,9) :: snsptdrk
         end module rrsw_kg21
         module rrsw_kg22 ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg22.f90
-            use parrrsw, only: ng22
             use parkind, only: im=>kind_im,rb=>kind_rb
-            real(kind=rb) dimension(16,9) :: snsptdrko
-            real(kind=rb) dimension(5,47,16) :: kbo
-            real(kind=rb) dimension(10,2) :: selfref
-            real(kind=rb) dimension(5,47,2) :: kb
-            real(kind=rb) dimension(16,9) :: sfluxrefo
-            real(kind=rb) dimension(9,5,13,16) :: kao
-            real(kind=rb) dimension(235,2) :: absb
-            real(kind=rb) dimension(2,9) :: irradnce
+            use parrrsw, only: ng22
             integer(kind=im), parameter,optional :: no22=16
-            real(kind=rb) dimension(9,5,13,2) :: ka
+            real(kind=rb) dimension(9,5,13,16) :: kao
+            real(kind=rb) dimension(5,47,16) :: kbo
             real(kind=rb) dimension(10,16) :: selfrefo
-            real(kind=rb) dimension(16,9) :: facbrghto
-            real(kind=rb) dimension(2,9) :: sfluxref
-            real(kind=rb) dimension(16,9) :: irradnceo
-            real(kind=rb) dimension(585,2) :: absa
-            real(kind=rb) dimension(3,2) :: forref
-            real(kind=rb) dimension(2,9) :: facbrght
             real(kind=rb) dimension(3,16) :: forrefo
+            real(kind=rb) dimension(16,9) :: sfluxrefo
+            real(kind=rb) dimension(16,9) :: irradnceo
+            real(kind=rb) dimension(16,9) :: facbrghto
+            real(kind=rb) dimension(16,9) :: snsptdrko
             real(kind=rb) :: rayl
+            real(kind=rb) dimension(9,5,13,2) :: ka
+            real(kind=rb) dimension(585,2) :: absa
+            real(kind=rb) dimension(5,47,2) :: kb
+            real(kind=rb) dimension(235,2) :: absb
+            real(kind=rb) dimension(10,2) :: selfref
+            real(kind=rb) dimension(3,2) :: forref
+            real(kind=rb) dimension(2,9) :: sfluxref
+            real(kind=rb) dimension(2,9) :: irradnce
+            real(kind=rb) dimension(2,9) :: facbrght
             real(kind=rb) dimension(2,9) :: snsptdrk
         end module rrsw_kg22
         module rrsw_kg23 ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg23.f90
-            use parrrsw, only: ng23
             use parkind, only: im=>kind_im,rb=>kind_rb
-            real(kind=rb) dimension(16) :: raylo
-            real(kind=rb) dimension(16) :: snsptdrko
-            real(kind=rb) dimension(10,10) :: selfref
-            real(kind=rb) dimension(16) :: sfluxrefo
-            real(kind=rb) dimension(5,13,16) :: kao
-            real(kind=rb) dimension(10) :: irradnce
+            use parrrsw, only: ng23
             integer(kind=im), parameter,optional :: no23=16
-            real(kind=rb) dimension(5,13,10) :: ka
+            real(kind=rb) dimension(5,13,16) :: kao
             real(kind=rb) dimension(10,16) :: selfrefo
-            real(kind=rb) dimension(16) :: facbrghto
-            real(kind=rb) dimension(10) :: sfluxref
-            real(kind=rb) dimension(16) :: irradnceo
-            real(kind=rb) dimension(65,10) :: absa
-            real(kind=rb) dimension(3,10) :: forref
-            real(kind=rb) dimension(10) :: facbrght
             real(kind=rb) dimension(3,16) :: forrefo
+            real(kind=rb) dimension(16) :: sfluxrefo
+            real(kind=rb) dimension(16) :: irradnceo
+            real(kind=rb) dimension(16) :: facbrghto
+            real(kind=rb) dimension(16) :: snsptdrko
+            real(kind=rb) dimension(16) :: raylo
+            real(kind=rb) dimension(5,13,10) :: ka
+            real(kind=rb) dimension(65,10) :: absa
+            real(kind=rb) dimension(10,10) :: selfref
+            real(kind=rb) dimension(3,10) :: forref
+            real(kind=rb) dimension(10) :: sfluxref
             real(kind=rb) dimension(10) :: rayl
+            real(kind=rb) dimension(10) :: irradnce
+            real(kind=rb) dimension(10) :: facbrght
             real(kind=rb) dimension(10) :: snsptdrk
         end module rrsw_kg23
         module rrsw_kg24 ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg24.f90
-            use parrrsw, only: ng24
             use parkind, only: im=>kind_im,rb=>kind_rb
-            real(kind=rb) dimension(16,9) :: snsptdrko
-            real(kind=rb) dimension(8,9) :: facbrght
+            use parrrsw, only: ng24
+            integer(kind=im), parameter,optional :: no24=16
+            real(kind=rb) dimension(9,5,13,16) :: kao
             real(kind=rb) dimension(5,47,16) :: kbo
-            real(kind=rb) dimension(10,8) :: selfref
+            real(kind=rb) dimension(10,16) :: selfrefo
+            real(kind=rb) dimension(3,16) :: forrefo
             real(kind=rb) dimension(16,9) :: sfluxrefo
+            real(kind=rb) dimension(16,9) :: irradnceo
+            real(kind=rb) dimension(16,9) :: facbrghto
+            real(kind=rb) dimension(16,9) :: snsptdrko
+            real(kind=rb) dimension(16) :: abso3ao
+            real(kind=rb) dimension(16) :: abso3bo
+            real(kind=rb) dimension(16,9) :: raylao
+            real(kind=rb) dimension(16) :: raylbo
+            real(kind=rb) dimension(9,5,13,8) :: ka
+            real(kind=rb) dimension(585,8) :: absa
+            real(kind=rb) dimension(5,47,8) :: kb
+            real(kind=rb) dimension(235,8) :: absb
+            real(kind=rb) dimension(10,8) :: selfref
             real(kind=rb) dimension(3,8) :: forref
-            real(kind=rb) dimension(8,9) :: rayla
+            real(kind=rb) dimension(8,9) :: sfluxref
+            real(kind=rb) dimension(8,9) :: irradnce
+            real(kind=rb) dimension(8,9) :: facbrght
+            real(kind=rb) dimension(8,9) :: snsptdrk
             real(kind=rb) dimension(8) :: abso3a
             real(kind=rb) dimension(8) :: abso3b
+            real(kind=rb) dimension(8,9) :: rayla
             real(kind=rb) dimension(8) :: raylb
-            real(kind=rb) dimension(9,5,13,16) :: kao
-            real(kind=rb) dimension(8,9) :: irradnce
-            real(kind=rb) dimension(16,9) :: raylao
-            real(kind=rb) dimension(16) :: abso3ao
-            real(kind=rb) dimension(5,47,8) :: kb
-            real(kind=rb) dimension(9,5,13,8) :: ka
-            real(kind=rb) dimension(10,16) :: selfrefo
-            real(kind=rb) dimension(16,9) :: facbrghto
-            integer(kind=im), parameter,optional :: no24=16
-            real(kind=rb) dimension(8,9) :: sfluxref
-            real(kind=rb) dimension(16) :: abso3bo
-            real(kind=rb) dimension(16,9) :: irradnceo
-            real(kind=rb) dimension(585,8) :: absa
-            real(kind=rb) dimension(235,8) :: absb
-            real(kind=rb) dimension(16) :: raylbo
-            real(kind=rb) dimension(3,16) :: forrefo
-            real(kind=rb) dimension(8,9) :: snsptdrk
         end module rrsw_kg24
         module rrsw_kg25 ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg25.f90
-            use parrrsw, only: ng25
             use parkind, only: im=>kind_im,rb=>kind_rb
-            real(kind=rb) dimension(16) :: raylo
-            real(kind=rb) dimension(16) :: snsptdrko
-            real(kind=rb) dimension(6) :: facbrght
+            use parrrsw, only: ng25
+            integer(kind=im), parameter,optional :: no25=16
             real(kind=rb) dimension(5,13,16) :: kao
+            real(kind=rb) dimension(16) :: sfluxrefo
+            real(kind=rb) dimension(16) :: irradnceo
+            real(kind=rb) dimension(16) :: facbrghto
+            real(kind=rb) dimension(16) :: snsptdrko
+            real(kind=rb) dimension(16) :: abso3ao
+            real(kind=rb) dimension(16) :: abso3bo
+            real(kind=rb) dimension(16) :: raylo
+            real(kind=rb) dimension(5,13,6) :: ka
+            real(kind=rb) dimension(65,6) :: absa
+            real(kind=rb) dimension(6) :: sfluxref
+            real(kind=rb) dimension(6) :: irradnce
+            real(kind=rb) dimension(6) :: facbrght
+            real(kind=rb) dimension(6) :: snsptdrk
             real(kind=rb) dimension(6) :: abso3a
             real(kind=rb) dimension(6) :: abso3b
-            real(kind=rb) dimension(6) :: irradnce
-            real(kind=rb) dimension(16) :: abso3ao
-            real(kind=rb) dimension(5,13,6) :: ka
-            real(kind=rb) dimension(16) :: facbrghto
-            integer(kind=im), parameter,optional :: no25=16
-            real(kind=rb) dimension(6) :: sfluxref
-            real(kind=rb) dimension(16) :: abso3bo
-            real(kind=rb) dimension(16) :: irradnceo
-            real(kind=rb) dimension(65,6) :: absa
-            real(kind=rb) dimension(16) :: sfluxrefo
             real(kind=rb) dimension(6) :: rayl
-            real(kind=rb) dimension(6) :: snsptdrk
         end module rrsw_kg25
         module rrsw_kg26 ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg26.f90
-            use parrrsw, only: ng26
             use parkind, only: im=>kind_im,rb=>kind_rb
-            real(kind=rb) dimension(16) :: raylo
-            real(kind=rb) dimension(16) :: snsptdrko
+            use parrrsw, only: ng26
             integer(kind=im), parameter,optional :: no26=16
             real(kind=rb) dimension(16) :: sfluxrefo
-            real(kind=rb) dimension(6) :: sfluxref
             real(kind=rb) dimension(16) :: irradnceo
+            real(kind=rb) dimension(16) :: facbrghto
+            real(kind=rb) dimension(16) :: snsptdrko
+            real(kind=rb) dimension(16) :: raylo
+            real(kind=rb) dimension(6) :: sfluxref
             real(kind=rb) dimension(6) :: irradnce
             real(kind=rb) dimension(6) :: facbrght
-            real(kind=rb) dimension(6) :: rayl
-            real(kind=rb) dimension(16) :: facbrghto
             real(kind=rb) dimension(6) :: snsptdrk
+            real(kind=rb) dimension(6) :: rayl
         end module rrsw_kg26
         module rrsw_kg27 ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg27.f90
-            use parrrsw, only: ng27
             use parkind, only: im=>kind_im,rb=>kind_rb
-            real(kind=rb) dimension(16) :: raylo
-            real(kind=rb) dimension(16) :: snsptdrko
+            use parrrsw, only: ng27
+            integer(kind=im), parameter,optional :: no27=16
+            real(kind=rb) dimension(5,13,16) :: kao
             real(kind=rb) dimension(5,47,16) :: kbo
             real(kind=rb) dimension(16) :: sfluxrefo
-            real(kind=rb) dimension(5,13,16) :: kao
-            real(kind=rb) dimension(8) :: irradnce
-            real(kind=rb) dimension(5,47,8) :: kb
-            real(kind=rb) dimension(5,13,8) :: ka
-            integer(kind=im), parameter,optional :: no27=16
-            real(kind=rb) dimension(16) :: facbrghto
-            real(kind=rb) dimension(8) :: sfluxref
             real(kind=rb) dimension(16) :: irradnceo
+            real(kind=rb) dimension(16) :: facbrghto
+            real(kind=rb) dimension(16) :: snsptdrko
+            real(kind=rb) dimension(16) :: raylo
+            real(kind=rb) dimension(5,13,8) :: ka
             real(kind=rb) dimension(65,8) :: absa
+            real(kind=rb) dimension(5,47,8) :: kb
             real(kind=rb) dimension(235,8) :: absb
+            real(kind=rb) dimension(8) :: sfluxref
+            real(kind=rb) dimension(8) :: irradnce
             real(kind=rb) dimension(8) :: facbrght
-            real(kind=rb) dimension(8) :: rayl
             real(kind=rb) dimension(8) :: snsptdrk
+            real(kind=rb) dimension(8) :: rayl
         end module rrsw_kg27
         module rrsw_kg28 ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg28.f90
-            use parrrsw, only: ng28
             use parkind, only: im=>kind_im,rb=>kind_rb
-            real(kind=rb) dimension(16,5) :: snsptdrko
+            use parrrsw, only: ng28
+            integer(kind=im), parameter,optional :: no28=16
+            real(kind=rb) dimension(9,5,13,16) :: kao
             real(kind=rb) dimension(5,5,47,16) :: kbo
             real(kind=rb) dimension(16,5) :: sfluxrefo
-            real(kind=rb) dimension(9,5,13,16) :: kao
-            real(kind=rb) dimension(6,5) :: irradnce
-            real(kind=rb) dimension(5,5,47,6) :: kb
-            real(kind=rb) dimension(9,5,13,6) :: ka
-            real(kind=rb) dimension(16,5) :: facbrghto
-            integer(kind=im), parameter,optional :: no28=16
-            real(kind=rb) dimension(6,5) :: sfluxref
             real(kind=rb) dimension(16,5) :: irradnceo
-            real(kind=rb) dimension(585,6) :: absa
-            real(kind=rb) dimension(1175,6) :: absb
-            real(kind=rb) dimension(6,5) :: facbrght
+            real(kind=rb) dimension(16,5) :: facbrghto
+            real(kind=rb) dimension(16,5) :: snsptdrko
             real(kind=rb) :: rayl
+            real(kind=rb) dimension(9,5,13,6) :: ka
+            real(kind=rb) dimension(585,6) :: absa
+            real(kind=rb) dimension(5,5,47,6) :: kb
+            real(kind=rb) dimension(1175,6) :: absb
+            real(kind=rb) dimension(6,5) :: sfluxref
+            real(kind=rb) dimension(6,5) :: irradnce
+            real(kind=rb) dimension(6,5) :: facbrght
             real(kind=rb) dimension(6,5) :: snsptdrk
         end module rrsw_kg28
         module rrsw_kg29 ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg29.f90
-            use parrrsw, only: ng29
             use parkind, only: im=>kind_im,rb=>kind_rb
-            real(kind=rb) dimension(16) :: snsptdrko
-            real(kind=rb) dimension(5,47,16) :: kbo
-            real(kind=rb) dimension(10,12) :: selfref
-            real(kind=rb) dimension(16) :: sfluxrefo
-            real(kind=rb) dimension(16) :: absh2oo
-            real(kind=rb) dimension(5,13,16) :: kao
-            real(kind=rb) dimension(4,12) :: forref
-            real(kind=rb) dimension(12) :: irradnce
-            real(kind=rb) dimension(12) :: absco2
-            real(kind=rb) dimension(16) :: absco2o
-            real(kind=rb) dimension(5,47,12) :: kb
-            real(kind=rb) dimension(5,13,12) :: ka
-            real(kind=rb) dimension(10,16) :: selfrefo
-            real(kind=rb) dimension(16) :: facbrghto
-            real(kind=rb) dimension(12) :: absh2o
+            use parrrsw, only: ng29
             integer(kind=im), parameter,optional :: no29=16
-            real(kind=rb) dimension(12) :: sfluxref
-            real(kind=rb) dimension(16) :: irradnceo
-            real(kind=rb) dimension(65,12) :: absa
-            real(kind=rb) dimension(235,12) :: absb
-            real(kind=rb) dimension(12) :: facbrght
+            real(kind=rb) dimension(5,13,16) :: kao
+            real(kind=rb) dimension(5,47,16) :: kbo
+            real(kind=rb) dimension(10,16) :: selfrefo
             real(kind=rb) dimension(4,16) :: forrefo
+            real(kind=rb) dimension(16) :: sfluxrefo
+            real(kind=rb) dimension(16) :: irradnceo
+            real(kind=rb) dimension(16) :: facbrghto
+            real(kind=rb) dimension(16) :: snsptdrko
+            real(kind=rb) dimension(16) :: absh2oo
+            real(kind=rb) dimension(16) :: absco2o
             real(kind=rb) :: rayl
+            real(kind=rb) dimension(5,13,12) :: ka
+            real(kind=rb) dimension(65,12) :: absa
+            real(kind=rb) dimension(5,47,12) :: kb
+            real(kind=rb) dimension(235,12) :: absb
+            real(kind=rb) dimension(10,12) :: selfref
+            real(kind=rb) dimension(4,12) :: forref
+            real(kind=rb) dimension(12) :: sfluxref
+            real(kind=rb) dimension(12) :: irradnce
+            real(kind=rb) dimension(12) :: facbrght
             real(kind=rb) dimension(12) :: snsptdrk
+            real(kind=rb) dimension(12) :: absh2o
+            real(kind=rb) dimension(12) :: absco2
         end module rrsw_kg29
         module rrsw_ncpar ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_ncpar.f90
             use parkind, only: im=>kind_im,rb=>kind_rb
-            integer(kind=im), parameter,optional :: maxabsorbernamelength=5
-            integer(kind=im), optional,dimension(14) :: bandnums=(/16, 17, 18, 19, 20, 21, 22,23, 24, 25, 26, 27, 28, 29/)
-            integer(kind=im), parameter,optional :: tdiff=5
-            real(kind=rb), optional,dimension(2) :: tempforeignupper=(/224, 260/)
-            integer(kind=im), parameter,optional :: gpoint=16
-            integer(kind=im), parameter,optional :: pupper=47
-            integer(kind=im), parameter,optional :: keylower=9
-            integer(kind=im), parameter,optional :: keyupper=5
-            integer(kind=im), parameter,optional :: ps=59
-            integer(kind=im), parameter,optional :: absorber=12
-            integer(kind=im), parameter,optional :: maxkeyspeciesnames=2
-            real(kind=rb), optional,dimension(5) :: keyspeciesupper=(/0.0, 0.25, 0.50, 0.75, 1.0/)
-            character(len=3), parameter,optional,dimension(14,2),depend(maxkeyspeciesnames,band) :: keyspeciesnamesupper=reshape(source=(/'ch4', 'h2o', 'ch4', 'co2', 'h2o', 'h2o', 'o2 ','', 'o2 ', '', '', 'o3 ', 'o3 ', 'co2','', 'co2', '', '', '', 'co2', '','', '', '', '', '', 'o2 ', ''/),shape=(/band, maxkeyspeciesnames/))
             real(kind=rb), parameter,optional :: cpdair=1003.5
             integer(kind=im) dimension(50) :: status
-            character(len=5), parameter,optional,dimension(12) :: absorbernames=(/'n2   ','ccl4 ','cfc11','cfc12','cfc22','h2o','co2','o3','n2o','co','ch4','o2'/)
-            real(kind=rb), optional,dimension(10) :: tempself=(/245.6,252.8,260.0,267.2,274.4,281.6,288.8,296.0,303.2,310.4/)
-            real(kind=rb), optional,dimension(9) :: keyspecieslower=(/1.0, 0.125, 0.25, 0.375,0.50, 0.625, 0.75, 0.875, 1.0/)
-            integer(kind=im), parameter,optional :: pforeign=4
-            integer(kind=im), parameter,optional :: band=14
+            integer(kind=im) :: i
+            integer(kind=im), parameter,optional :: keylower=9
+            integer(kind=im), parameter,optional :: keyupper=5
+            integer(kind=im), parameter,optional :: tdiff=5
+            integer(kind=im), parameter,optional :: ps=59
+            integer(kind=im), parameter,optional :: plower=13
+            integer(kind=im), parameter,optional :: pupper=47
+            integer(kind=im), parameter,optional :: tself=10
             integer(kind=im), parameter,optional :: tforeignlower=3
             integer(kind=im), parameter,optional :: tforeignupper=2
-            real(kind=rb), optional,dimension(5) :: tempdiffs=(/-30,-15, 0, 15, 30/)
-            character(len=3), parameter,optional,dimension(14,2),depend(maxkeyspeciesnames,band) :: keyspeciesnameslower=reshape(source=(/'h2o', 'h2o', 'h2o', 'h2o', 'h2o', 'h2o', 'h2o','h2o', 'h2o', 'h2o', '', 'o3 ', 'o3 ', 'h2o','ch4', 'co2', 'ch4', 'co2', '', 'co2', 'o2 ','', 'o2 ', '', '', '', 'o2 ', ''/),shape=(/band, maxkeyspeciesnames/))
-            integer(kind=im), parameter,optional :: tself=10
-            integer(kind=im), parameter,optional :: gpointset=2
-            integer(kind=im), parameter,optional :: maxkeyspeciesnamelength=3
-            real(kind=rb), optional,dimension(19) :: temp=(/188.0, 195.2, 202.4, 209.6, 216.8, 224.0,231.2, 238.4, 245.6, 252.8, 260.0, 267.2,274.4, 281.6, 288.8, 296.0, 303.2, 310.4, 317.6/)
-            integer(kind=im) :: i
-            real(kind=rb), optional,dimension(4) :: pressforeign=(/970, 475, 219, 3/)
-            integer(kind=im), parameter,optional :: plower=13
+            integer(kind=im), parameter,optional :: pforeign=4
             integer(kind=im), parameter,optional :: t=19
+            integer(kind=im), parameter,optional :: band=14
+            integer(kind=im), parameter,optional :: gpoint=16
+            integer(kind=im), parameter,optional :: gpointset=2
+            integer(kind=im), parameter,optional :: maxabsorbernamelength=5
+            integer(kind=im), parameter,optional :: absorber=12
+            integer(kind=im), parameter,optional :: maxkeyspeciesnamelength=3
+            integer(kind=im), parameter,optional :: maxkeyspeciesnames=2
+            character(len=5), parameter,optional,dimension(12) :: absorbernames=(/'n2   ','ccl4 ','cfc11','cfc12','cfc22','h2o  ','co2  ','o3   ','n2o  ','co   ','ch4  ','o2   '/)
+            character(len=3), parameter,optional,dimension(14,2),depend(band,maxkeyspeciesnames) :: keyspeciesnameslower=reshape(source=(/'h2o', 'h2o', 'h2o', 'h2o', 'h2o', 'h2o', 'h2o','h2o', 'h2o', 'h2o', '   ', 'o3 ', 'o3 ', 'h2o','ch4', 'co2', 'ch4', 'co2', '   ', 'co2', 'o2 ','   ', 'o2 ', '   ', '   ', '   ', 'o2 ', '   '/),shape=(/band, maxkeyspeciesnames/))
+            character(len=3), parameter,optional,dimension(14,2),depend(band,maxkeyspeciesnames) :: keyspeciesnamesupper=reshape(source=(/'ch4', 'h2o', 'ch4', 'co2', 'h2o', 'h2o', 'o2 ','   ', 'o2 ', '   ', '   ', 'o3 ', 'o3 ', 'co2','   ', 'co2', '   ', '   ', '   ', 'co2', '   ','   ', '   ', '   ', '   ', '   ', 'o2 ', '   '/),shape=(/band, maxkeyspeciesnames/))
+            integer(kind=im), optional,dimension(14) :: bandnums=(/16, 17, 18, 19, 20, 21, 22,23, 24, 25, 26, 27, 28, 29/)
+            real(kind=rb), optional,dimension(9) :: keyspecieslower=(/1.0, 0.125, 0.25, 0.375,0.50, 0.625, 0.75, 0.875, 1.0/)
+            real(kind=rb), optional,dimension(5) :: keyspeciesupper=(/0.0, 0.25, 0.50, 0.75, 1.0/)
+            real(kind=rb), optional,dimension(5) :: tempdiffs=(/-30,-15, 0, 15, 30/)
+            real(kind=rb), optional,dimension(10) :: tempself=(/245.6,252.8,260.0,267.2,274.4,281.6,288.8,296.0,303.2,310.4/)
             real(kind=rb), optional,dimension(3) :: tempforeignlower=(/296, 260, 224/)
+            real(kind=rb), optional,dimension(2) :: tempforeignupper=(/224, 260/)
+            real(kind=rb), optional,dimension(4) :: pressforeign=(/970, 475, 219, 3/)
+            real(kind=rb), optional,dimension(19) :: temp=(/188.0, 195.2, 202.4, 209.6, 216.8, 224.0,231.2, 238.4, 245.6, 252.8, 260.0, 267.2,274.4, 281.6, 288.8, 296.0, 303.2, 310.4, 317.6/)
             subroutine getabsorberindex(absorbername,absorberindex) ! in :_rrtmg_sw:rrtmg_sw_v4.0/gcm_model/modules/rrsw_ncpar.f90:rrsw_ncpar
                 character*(*) intent(in) :: absorbername
                 integer(kind=im) intent(out) :: absorberindex
             end subroutine getabsorberindex
         end module rrsw_ncpar
         subroutine climlab_rrtmg_sw_ini(cpdair) ! in :_rrtmg_sw:Driver.f90
-            use rrtmg_sw_init, only: rrtmg_sw_ini
             use parkind, only: rb=>kind_rb
+            use rrtmg_sw_init, only: rrtmg_sw_ini
             real(kind=rb) intent(in) :: cpdair
         end subroutine climlab_rrtmg_sw_ini
         subroutine climlab_mcica_subcol_sw(ncol,nlay,icld,permuteseed,irng,play,cldfrac,ciwp,clwp,reic,relq,tauc,ssac,asmc,fsfc,cldfmcl,ciwpmcl,clwpmcl,reicmcl,relqmcl,taucmcl,ssacmcl,asmcmcl,fsfcmcl) ! in :_rrtmg_sw:Driver.f90
-            use parrrsw, only: naerec,ngptsw,nbndsw
-            use mcica_subcol_gen_sw, only: mcica_subcol_sw
             use parkind, only: im=>kind_im
+            use mcica_subcol_gen_sw, only: mcica_subcol_sw
+            use parrrsw, only: nbndsw,ngptsw,naerec
             integer(kind=im) intent(in) :: ncol
             integer(kind=im) intent(in) :: nlay
             integer(kind=im) intent(inout) :: icld
@@ -455,17 +455,17 @@ python module _rrtmg_sw ! in
             real(kind=8) dimension(112,ncol,nlay),intent(out),depend(ncol,nlay) :: fsfcmcl
         end subroutine climlab_mcica_subcol_sw
         subroutine climlab_rrtmg_sw(ncol,nlay,icld,iaer,play,plev,tlay,tlev,tsfc,h2ovmr,o3vmr,co2vmr,ch4vmr,n2ovmr,o2vmr,asdir,asdif,aldir,aldif,coszen,adjes,dyofyr,scon,isolvar,inflgsw,iceflgsw,liqflgsw,cldfmcl,taucmcl,ssacmcl,asmcmcl,fsfcmcl,ciwpmcl,clwpmcl,reicmcl,relqmcl,tauaer,ssaaer,asmaer,ecaer,bndsolvar,indsolvar,solcycfrac,swuflx,swdflx,swhr,swuflxc,swdflxc,swhrc) ! in :_rrtmg_sw:Driver.f90
-            use parrrsw, only: naerec,ngptsw,nbndsw
             use parkind, only: im=>kind_im
+            use parrrsw, only: nbndsw,ngptsw,naerec
             use rrtmg_sw_rad, only: rrtmg_sw
             integer(kind=im) intent(in) :: ncol
             integer(kind=im) intent(in) :: nlay
             integer(kind=im) intent(inout) :: icld
             integer(kind=im) intent(inout) :: iaer
             real(kind=8) dimension(ncol,nlay),intent(in),depend(ncol,nlay) :: play
-            real(kind=8) dimension(ncol,nlay + 1),intent(in),depend(ncol,nlay) :: plev
+            real(kind=8) dimension(ncol,1 + nlay),intent(in),depend(ncol,nlay) :: plev
             real(kind=8) dimension(ncol,nlay),intent(in),depend(ncol,nlay) :: tlay
-            real(kind=8) dimension(ncol,nlay + 1),intent(in),depend(ncol,nlay) :: tlev
+            real(kind=8) dimension(ncol,1 + nlay),intent(in),depend(ncol,nlay) :: tlev
             real(kind=8) dimension(ncol),intent(in),depend(ncol) :: tsfc
             real(kind=8) dimension(ncol,nlay),intent(in),depend(ncol,nlay) :: h2ovmr
             real(kind=8) dimension(ncol,nlay),intent(in),depend(ncol,nlay) :: o3vmr
@@ -478,7 +478,7 @@ python module _rrtmg_sw ! in
             real(kind=8) dimension(ncol),intent(in),depend(ncol) :: aldir
             real(kind=8) dimension(ncol),intent(in),depend(ncol) :: aldif
             real(kind=8) dimension(ncol),intent(in),depend(ncol) :: coszen
-            real(kind=8) intent(in) :: adjes
+            real(kind=8) dimension(ncol),intent(in),depend(ncol) :: adjes
             integer(kind=im) intent(in) :: dyofyr
             real(kind=8) intent(in) :: scon
             integer(kind=im) intent(in) :: isolvar
@@ -501,15 +501,16 @@ python module _rrtmg_sw ! in
             real(kind=8) dimension(14),intent(inout) :: bndsolvar
             real(kind=8) dimension(2),intent(inout) :: indsolvar
             real(kind=8) intent(inout) :: solcycfrac
-            real(kind=8) dimension(ncol,nlay + 1),intent(out),depend(ncol,nlay) :: swuflx
-            real(kind=8) dimension(ncol,nlay + 1),intent(out),depend(ncol,nlay) :: swdflx
+            real(kind=8) dimension(ncol,1 + nlay),intent(out),depend(ncol,nlay) :: swuflx
+            real(kind=8) dimension(ncol,1 + nlay),intent(out),depend(ncol,nlay) :: swdflx
             real(kind=8) dimension(ncol,nlay),intent(out),depend(ncol,nlay) :: swhr
-            real(kind=8) dimension(ncol,nlay + 1),intent(out),depend(ncol,nlay) :: swuflxc
-            real(kind=8) dimension(ncol,nlay + 1),intent(out),depend(ncol,nlay) :: swdflxc
+            real(kind=8) dimension(ncol,1 + nlay),intent(out),depend(ncol,nlay) :: swuflxc
+            real(kind=8) dimension(ncol,1 + nlay),intent(out),depend(ncol,nlay) :: swdflxc
             real(kind=8) dimension(ncol,nlay),intent(out),depend(ncol,nlay) :: swhrc
         end subroutine climlab_rrtmg_sw
     end interface 
 end python module _rrtmg_sw
 
-! This file was auto-generated with f2py (version:2).
-! See http://cens.ioc.ee/projects/f2py2e/
+! This file was auto-generated with f2py (version:1.26.4).
+! See:
+! https://web.archive.org/web/20140822061353/http://cens.ioc.ee/projects/f2py2e

--- a/climlab_rrtmg/rrtmg_sw/sourcemods/rrtmg_sw_rad.f90
+++ b/climlab_rrtmg/rrtmg_sw/sourcemods/rrtmg_sw_rad.f90
@@ -263,7 +263,8 @@
 
       integer(kind=im), intent(in) :: dyofyr          ! Day of the year (used to get Earth/Sun
                                                       !  distance if adjflx not provided)
-      real(kind=rb), intent(in) :: adjes              ! Flux adjustment for Earth/Sun distance
+      !  CLIMLAB change adjes to an array value, same dimensions as coszen
+      real(kind=rb), intent(in) :: adjes(:)           ! Flux adjustment for Earth/Sun distance
       real(kind=rb), intent(in) :: coszen(:)          ! Cosine of solar zenith angle
                                                       !    Dimensions: (ncol)
       real(kind=rb), intent(in) :: scon               ! Solar constant (W/m2)
@@ -935,7 +936,8 @@
 
       integer(kind=im), intent(in) :: dyofyr          ! Day of the year (used to get Earth/Sun
                                                       !  distance if adjflx not provided)
-      real(kind=rb), intent(in) :: adjes              ! Flux adjustment for Earth/Sun distance
+      !  CLIMLAB change adjes to an array value, same dimensions as coszen
+      real(kind=rb), intent(in) :: adjes(:)           ! Flux adjustment for Earth/Sun distance
       real(kind=rb), intent(in) :: scon               ! Solar constant (W/m2)
                                                       !    Total solar irradiance averaged
                                                       !    over the solar cycle.

--- a/climlab_rrtmg/rrtmg_sw/sourcemods/rrtmg_sw_rad.f90
+++ b/climlab_rrtmg/rrtmg_sw/sourcemods/rrtmg_sw_rad.f90
@@ -940,8 +940,7 @@
 
       integer(kind=im), intent(in) :: dyofyr          ! Day of the year (used to get Earth/Sun
                                                       !  distance if adjflx not provided)
-      !  CLIMLAB change adjes to an array value, same dimensions as coszen
-      real(kind=rb), intent(in) :: adjes(:)           ! Flux adjustment for Earth/Sun distance
+      real(kind=rb), intent(in) :: adjes              ! Flux adjustment for Earth/Sun distance
       real(kind=rb), intent(in) :: scon               ! Solar constant (W/m2)
                                                       !    Total solar irradiance averaged
                                                       !    over the solar cycle.

--- a/climlab_rrtmg/rrtmg_sw/sourcemods/rrtmg_sw_rad.f90
+++ b/climlab_rrtmg/rrtmg_sw/sourcemods/rrtmg_sw_rad.f90
@@ -1253,9 +1253,7 @@
 
 ! Set flux adjustment for current Earth/Sun distance (two options).
 ! 1) Use Earth/Sun distance flux adjustment provided by GCM (input as adjes);
-   ! CLIMLAB we will apply adjes later, for now assume the global value is 1
-      ! adjflx = adjes
-      adjflx = 1.0_rb
+      adjflx = adjes
 !
 ! 2) Calculate Earth/Sun distance from DYOFYR, the cumulative day of the year.
 !    (Set adjflx to 1. to use constant Earth/Sun distance of 1 AU).

--- a/climlab_rrtmg/rrtmg_sw/sourcemods/rrtmg_sw_rad.f90
+++ b/climlab_rrtmg/rrtmg_sw/sourcemods/rrtmg_sw_rad.f90
@@ -423,6 +423,8 @@
 
 !      real(kind=rb) :: earth_sun             ! function for Earth/Sun distance factor
       real(kind=rb) :: cossza                 ! Cosine of solar zenith angle
+      ! CLIMLAB new local variable
+      real(kind=rb) :: adjes_local            ! individual column value of irradiance adjustment
       real(kind=rb) :: adjflux(jpband)        ! adjustment for current Earth/Sun distance
       real(kind=rb) :: albdir(nbndsw)         ! surface albedo, direct          ! zalbp
       real(kind=rb) :: albdif(nbndsw)         ! surface albedo, diffuse         ! zalbd
@@ -617,13 +619,16 @@
 
       do iplon = 1, ncol
 
+! CLIMLAB here pass a single-column value of adjes to inatm_sw as we are in the column loop
+         adjes_local = adjes(iplon)
+
 ! Prepare atmosphere profile from GCM for use in RRTMG, and define
 ! other input parameters
 
          call inatm_sw (iplon, nlay, icld, iaer, &
               play, plev, tlay, tlev, tsfc, h2ovmr, &
               o3vmr, co2vmr, ch4vmr, n2ovmr, o2vmr, &
-              adjes, dyofyr, scon, isolvar, &
+              adjes_local, dyofyr, scon, isolvar, &
               inflgsw, iceflgsw, liqflgsw, &
               cldfmcl, taucmcl, ssacmcl, asmcmcl, fsfcmcl, ciwpmcl, clwpmcl, &
               reicmcl, relqmcl, tauaer, ssaaer, asmaer, &
@@ -636,7 +641,6 @@
 ! CLIMLAB second-last time is solar variability
 ! CLIMLAB last line is optional
 ! CLIMLAB moved comment lines out of subroutine call
-
 
 !  For cloudy atmosphere, use cldprmc to set cloud optical properties based on
 !  input cloud physical properties.  Select method based on choices described
@@ -1249,7 +1253,9 @@
 
 ! Set flux adjustment for current Earth/Sun distance (two options).
 ! 1) Use Earth/Sun distance flux adjustment provided by GCM (input as adjes);
-      adjflx = adjes
+   ! CLIMLAB we will apply adjes later, for now assume the global value is 1
+      ! adjflx = adjes
+      adjflx = 1.0_rb
 !
 ! 2) Calculate Earth/Sun distance from DYOFYR, the cumulative day of the year.
 !    (Set adjflx to 1. to use constant Earth/Sun distance of 1 AU).

--- a/climlab_rrtmg/tests/test_climlab_rrtmg.py
+++ b/climlab_rrtmg/tests/test_climlab_rrtmg.py
@@ -399,7 +399,8 @@ def test_rrtmg_sw_multicol():
     # insolation
     scon = 1365.2  # solar constant
     coszen_2d = np.tile(1/4, [ncol])  # cosine of zenith angle
-    adjes_2d = np.tile(1., [ncol])  # instantaneous irradiance = scon * eccentricity_factor
+    # irradiance is twice as large in column 0
+    adjes_2d = np.array([1., 0.5])  # instantaneous irradiance = scon * eccentricity_factor
     dyofyr = 0       # day of the year used to get Earth/Sun distance (if not adjes)
     # new arguments for RRTMG_SW version 4.0
     isolvar = -1    # ! Flag for solar variability method
@@ -436,3 +437,6 @@ def test_rrtmg_sw_multicol():
                 ciwpmcl_2d, clwpmcl_2d, reicmcl_2d, relqmcl_2d,
                 tauaer_2d, ssaaer_2d, asmaer_2d, ecaer_2d,
                 bndsolvar, indsolvar, solcycfrac)
+
+    # The downwelling SW at top of model should be twice as large in column 0
+    assert np.isclose(swdflx[0,-1], 2*swdflx[1,-1])

--- a/climlab_rrtmg/tests/test_climlab_rrtmg.py
+++ b/climlab_rrtmg/tests/test_climlab_rrtmg.py
@@ -353,3 +353,86 @@ def test_rrtmg_sw_mcica():
                 ciwpmcl, clwpmcl, reicmcl, relqmcl,
                 tauaer, ssaaer, asmaer, ecaer,
                 bndsolvar, indsolvar, solcycfrac)
+
+def test_rrtmg_sw_multicol():
+    ncol = 2
+    plev_2d = np.tile(plev, [ncol, 1])
+    play_2d = np.tile(play, [ncol, 1])
+    tlay_2d = np.tile(tlay, [ncol, 1])
+    tlev_2d = np.tile(tlev, [ncol, 1])
+    tsfc_2d = np.tile(tsfc, [ncol])
+    h2ovmr_2d = np.tile(h2ovmr, [ncol, 1])
+    o3vmr_2d = np.tile(o3vmr, [ncol, 1])
+    co2vmr_2d = np.tile(co2vmr, [ncol, 1])
+    ch4vmr_2d = np.tile(ch4vmr, [ncol, 1])
+    n2ovmr_2d = np.tile(n2ovmr, [ncol, 1])
+    o2vmr_2d = np.tile(o2vmr, [ncol, 1])
+
+    nbndsw = int(rrtmg_sw.parrrsw.nbndsw)
+    naerec = int(rrtmg_sw.parrrsw.naerec)
+    ngptsw = int(rrtmg_sw.parrrsw.ngptsw)
+    #  Initialize absorption data
+    rrtmg_sw.climlab_rrtmg_sw_ini(cp)
+    #  Lots of RRTMG parameters
+    icld = 0    # Cloud overlap method, 0: Clear only, 1: Random, 2,  Maximum/random] 3: Maximum
+    dyofyr = 0       # day of the year used to get Earth/Sun distance (if not adjes)
+    inflgsw  = 2
+    iceflgsw = 1
+    liqflgsw = 1
+    # AEROSOLS
+    iaer = 0   #! Aerosol option flag
+                #!    0: No aerosol
+                #!    6: ECMWF method: use six ECMWF aerosol types input aerosol optical depth at 0.55 microns for each aerosol type (ecaer)
+                #!    10:Input aerosol optical properties: input total aerosol optical depth, single scattering albedo and asymmetry parameter (tauaer, ssaaer, asmaer) directly
+    tauaer_2d = 0. * np.ones_like(play_2d)   # Aerosol optical depth (iaer=10 only), Dimensions,  (ncol,nlay,nbndsw)] #  (non-delta scaled)
+    #  broadcast and transpose to get [ncol,nlay,nbndsw]
+    tauaer_2d = np.transpose(tauaer_2d * np.ones([nbndsw,ncol,nlay]), (1,2,0))
+    ssaaer_2d = 0. * np.ones_like(play)   # Aerosol single scattering albedo (iaer=10 only), Dimensions,  (ncol,nlay,nbndsw)] #  (non-delta scaled)
+    #  broadcast and transpose to get [ncol,nlay,nbndsw]
+    ssaaer_2d = np.transpose(ssaaer_2d * np.ones([nbndsw,ncol,nlay]), (1,2,0))
+    asmaer_2d = 0. * np.ones_like(play_2d)   # Aerosol asymmetry parameter (iaer=10 only), Dimensions,  (ncol,nlay,nbndsw)] #  (non-delta scaled)
+    #  broadcast and transpose to get [ncol,nlay,nbndsw]
+    asmaer_2d = np.transpose(asmaer_2d * np.ones([nbndsw,ncol,nlay]), (1,2,0))
+    ecaer_2d  = 0. * np.ones_like(play_2d)   # Aerosol optical depth at 0.55 micron (iaer=6 only), Dimensions,  (ncol,nlay,naerec)] #  (non-delta scaled)
+    #  broadcast and transpose to get [ncol,nlay,naerec]
+    ecaer_2d = np.transpose(ecaer_2d * np.ones([naerec,ncol,nlay]), (1,2,0))
+    # insolation
+    scon = 1365.2  # solar constant
+    coszen_2d = np.tile(1/4, [ncol])  # cosine of zenith angle
+    adjes = 1.  # instantaneous irradiance = scon * eccentricity_factor
+    dyofyr = 0       # day of the year used to get Earth/Sun distance (if not adjes)
+    # new arguments for RRTMG_SW version 4.0
+    isolvar = -1    # ! Flag for solar variability method
+    indsolvar = np.ones(2)      # Facular and sunspot amplitude scale factors (isolvar=1),
+                                 # or Mg and SB indices (isolvar=2)
+    bndsolvar = np.ones(nbndsw) # Solar variability scale factors for each shortwave band
+    solcycfrac = 1.              # Fraction of averaged solar cycle (0-1) at current time (isolvar=1)
+
+    # surface albedo
+    aldif_2d = 0.3 * np.ones_like(tsfc_2d)
+    aldir_2d = 0.3 * np.ones_like(tsfc_2d)
+    asdif_2d = 0.3 * np.ones_like(tsfc_2d)
+    asdir_2d = 0.3 * np.ones_like(tsfc_2d)
+
+    # Clear-sky only
+    cldfmcl_2d = np.zeros((ngptsw,ncol,nlay))
+    ciwpmcl_2d = np.zeros((ngptsw,ncol,nlay))
+    clwpmcl_2d = np.zeros((ngptsw,ncol,nlay))
+    reicmcl_2d = np.zeros((ncol,nlay))
+    relqmcl_2d = np.zeros((ncol,nlay))
+    taucmcl_2d = np.zeros((ngptsw,ncol,nlay))
+    ssacmcl_2d = np.zeros((ngptsw,ncol,nlay))
+    asmcmcl_2d = np.zeros((ngptsw,ncol,nlay))
+    fsfcmcl_2d = np.zeros((ngptsw,ncol,nlay))
+
+    (swuflx, swdflx, swhr, swuflxc, swdflxc, swhrc) = \
+            rrtmg_sw.climlab_rrtmg_sw(ncol, nlay, icld, iaer,
+                play_2d, plev_2d, tlay_2d, tlev_2d, tsfc_2d,
+                h2ovmr_2d, o3vmr_2d, co2vmr_2d, ch4vmr_2d, n2ovmr_2d, o2vmr_2d,
+                asdir_2d, asdif_2d, aldir_2d, aldif_2d,
+                coszen_2d, adjes, dyofyr, scon, isolvar,
+                inflgsw, iceflgsw, liqflgsw, cldfmcl_2d,
+                taucmcl_2d, ssacmcl_2d, asmcmcl_2d, fsfcmcl_2d,
+                ciwpmcl_2d, clwpmcl_2d, reicmcl_2d, relqmcl_2d,
+                tauaer_2d, ssaaer_2d, asmaer_2d, ecaer_2d,
+                bndsolvar, indsolvar, solcycfrac)

--- a/climlab_rrtmg/tests/test_climlab_rrtmg.py
+++ b/climlab_rrtmg/tests/test_climlab_rrtmg.py
@@ -399,7 +399,7 @@ def test_rrtmg_sw_multicol():
     # insolation
     scon = 1365.2  # solar constant
     coszen_2d = np.tile(1/4, [ncol])  # cosine of zenith angle
-    adjes = 1.  # instantaneous irradiance = scon * eccentricity_factor
+    adjes_2d = np.tile(1., [ncol])  # instantaneous irradiance = scon * eccentricity_factor
     dyofyr = 0       # day of the year used to get Earth/Sun distance (if not adjes)
     # new arguments for RRTMG_SW version 4.0
     isolvar = -1    # ! Flag for solar variability method
@@ -430,7 +430,7 @@ def test_rrtmg_sw_multicol():
                 play_2d, plev_2d, tlay_2d, tlev_2d, tsfc_2d,
                 h2ovmr_2d, o3vmr_2d, co2vmr_2d, ch4vmr_2d, n2ovmr_2d, o2vmr_2d,
                 asdir_2d, asdif_2d, aldir_2d, aldif_2d,
-                coszen_2d, adjes, dyofyr, scon, isolvar,
+                coszen_2d, adjes_2d, dyofyr, scon, isolvar,
                 inflgsw, iceflgsw, liqflgsw, cldfmcl_2d,
                 taucmcl_2d, ssacmcl_2d, asmcmcl_2d, fsfcmcl_2d,
                 ciwpmcl_2d, clwpmcl_2d, reicmcl_2d, relqmcl_2d,

--- a/climlab_rrtmg/tests/test_climlab_rrtmg.py
+++ b/climlab_rrtmg/tests/test_climlab_rrtmg.py
@@ -400,7 +400,8 @@ def test_rrtmg_sw_multicol():
     scon = 1365.2  # solar constant
     coszen_2d = np.tile(1/4, [ncol])  # cosine of zenith angle
     # irradiance is twice as large in column 0
-    adjes_2d = np.array([1., 0.5])  # instantaneous irradiance = scon * eccentricity_factor
+    irradiance_factor = 2.
+    adjes_2d = np.array([irradiance_factor, 1.])  # instantaneous irradiance = scon * eccentricity_factor
     dyofyr = 0       # day of the year used to get Earth/Sun distance (if not adjes)
     # new arguments for RRTMG_SW version 4.0
     isolvar = -1    # ! Flag for solar variability method
@@ -439,4 +440,4 @@ def test_rrtmg_sw_multicol():
                 bndsolvar, indsolvar, solcycfrac)
 
     # The downwelling SW at top of model should be twice as large in column 0
-    assert np.isclose(swdflx[0,-1], 2*swdflx[1,-1])
+    assert np.isclose(swdflx[0,-1], irradiance_factor*swdflx[1,-1])


### PR DESCRIPTION
Closes #26 

This PR will add support for arrays of values for input parameter `adjes` (same dimensions as `coszen`).

To do:

- [x] Create a multi-column RRTMG_SW test with scalar `adjes` (it should pass, we should have this test already but don't)
- [x] Give that test a non-scalar value of `adjes` (it should fail)
- [x] Modify whichever layers of fortran code are needed to support array values for `adjes`
- [x] Make sure the test is passing.