### PR TITLE
working build python3.10 ubuntu

### DIFF
--- a/climlab_rrtmg/rrtmg_lw/Driver.f90
+++ b/climlab_rrtmg/rrtmg_lw/Driver.f90
@@ -42,7 +42,9 @@ subroutine climlab_mcica_subcol_lw &
     ! Modules
     use parkind, only : im => kind_im
     use mcica_subcol_gen_lw, only: mcica_subcol_lw
-    use parrrtm, only: nbndlw, ngptlw
+    !use parrrtm, only: nbndlw, ngptlw
+    integer(kind=im), parameter :: nbndlw = 16
+    integer(kind=im), parameter :: ngptlw = 140  
 
 ! Input
     integer, parameter :: rb = selected_real_kind(12)
@@ -79,8 +81,9 @@ subroutine climlab_mcica_subcol_lw &
 !f2py depend(ncol,nlay) play,
 !f2py depend(ncol,nlay) cldfrac,ciwp,clwp,reic,relq
 !f2py depend(ncol,nlay) tauc
-! !f2py depend(ncol,nlay) cldfmcl,ciwpmcl,clwpmcl,taucmcl
-! !f2py depend(ncol,nlay) reicmcl,relqmcl
+!f2py depend(ncol,nlay) cldfmcl,ciwpmcl,clwpmcl
+!f2py depend(ncol,nlay) reicmcl,relqmcl
+!f2py depend(ncol,nlay) taucmcl
 
     ! Call the Monte Carlo Independent Column Approximation
     !   (McICA, Pincus et al., JC, 2003)
@@ -103,8 +106,10 @@ subroutine climlab_rrtmg_lw &
 
 ! Modules
     use parkind, only : im => kind_im
-    use parrrtm, only: nbndlw, ngptlw
     use rrtmg_lw_rad, only: rrtmg_lw
+    !use parrrtm, only: nbndlw, ngptlw
+    integer(kind=im), parameter :: nbndlw = 16
+    integer(kind=im), parameter :: ngptlw = 140  
 
 ! Input
     integer, parameter :: rb = selected_real_kind(12)

--- a/climlab_rrtmg/rrtmg_sw/Driver.f90
+++ b/climlab_rrtmg/rrtmg_sw/Driver.f90
@@ -43,7 +43,9 @@ subroutine climlab_mcica_subcol_sw &
 ! Modules
   use parkind, only : im => kind_im
   use mcica_subcol_gen_sw, only: mcica_subcol_sw
-  use parrrsw, only: nbndsw, ngptsw, naerec
+  !use parrrsw, only: nbndsw, ngptsw
+  integer(kind=im), parameter :: nbndsw = 14
+  integer(kind=im), parameter :: ngptsw = 112
 
 ! Input
   integer, parameter :: rb = selected_real_kind(12)
@@ -114,19 +116,21 @@ subroutine climlab_rrtmg_sw &
 
 ! Modules
     use parkind, only : im => kind_im
-    use parrrsw, only: nbndsw, ngptsw, naerec
     use rrtmg_sw_rad, only: rrtmg_sw
-
+    ! use parrrsw, only: nbndsw, ngptsw, naerec
+    integer(kind=im), parameter :: nbndsw = 14
+    integer(kind=im), parameter :: naerec  = 6
+    integer(kind=im), parameter :: ngptsw = 112
 ! Input
     integer, parameter :: rb = selected_real_kind(12)
     integer(kind=im), intent(in) :: ncol            ! number of columns
     integer(kind=im), intent(in) :: nlay            ! number of model layers
-    integer(kind=im), intent(inout) :: icld         ! Cloud overlap method
+    integer(kind=im), intent(inout) :: icld            ! Cloud overlap method
                                                     !    0: Clear only
                                                     !    1: Random
                                                     !    2: Maximum/random
                                                     !    3: Maximum
-    integer(kind=im), intent(inout) :: iaer         ! Aerosol option flag
+    integer(kind=im), intent(inout) :: iaer            ! Aerosol option flag
                                                     !    0: No aerosol
                                                     !    6: ECMWF method
                                                     !    10:Input aerosol optical
@@ -147,7 +151,7 @@ subroutine climlab_rrtmg_sw &
     real(kind=rb), intent(in) :: asdif(ncol)        ! UV/vis surface albedo: diffuse rad
     real(kind=rb), intent(in) :: asdir(ncol)        ! Near-IR surface albedo: diffuse rad
     real(kind=rb), intent(in) :: coszen(ncol)       ! Cosine of solar zenith angle
-    real(kind=rb), intent(in) :: adjes(ncol)        ! Flux adjustment (Earth/Sun distance and/or zenith angle compensation)
+    real(kind=rb), intent(in) :: adjes(ncol)        ! Flux adjustment for Earth/Sun distance
     integer(kind=im), intent(in) :: dyofyr          ! Day of the year (used to get Earth/Sun
                                                     !  distance if adjflx not provided)
     real(kind=rb), intent(in) :: scon               ! Solar constant (W/m2)
@@ -236,13 +240,20 @@ subroutine climlab_rrtmg_sw &
     real(kind=rb), intent(out) :: swhrc(ncol,nlay)       ! Clear sky shortwave radiative heating rate (K/d)
 
 !  These are not comments! Necessary directives to f2py to handle array dimensions
-!f2py depend(ncol,nlay) play, plev, tlay, tlev
+!f2py depend(ncol,nlay) play
+!f2py depend(ncol,nlay) plev
+!f2py depend(ncol,nlay) tlay
+!f2py depend(ncol,nlay) tlev
 !f2py depend(ncol,nlay) h2ovmr,o3vmr,co2vmr,ch4vmr,n2ovmr,o2vmr
-!f2py depend(ncol) tsfc, aldif, aldir, asdif, asdir, coszen, adjes
-!f2py depend(ncol,nlay) tauaer,ssaaer,asmaer,ecaer
+!f2py depend(ncol) asdir,asdif,aldir,aldif,coszen, adjes, tsfc
+!f2py depend(ncol,nlay) cldfmcl,taucmcl,ssacmcl,asmcmcl,fsfcmcl
+!f2py depend(ncol,nlay) ciwpmcl,clwpmcl
 !f2py depend(ncol,nlay) reicmcl,relqmcl
-!f2py depend(ncol,nlay) cldfmcl,ciwpmcl,clwpmcl,taucmcl,ssacmcl,asmcmcl,fsfcmcl
-!f2py depend(ncol,nlay) swuflx,swdflx,swhr,swuflxc,swdflxc,swhrc
+!f2py depend(ncol,nlay) tauaer,ssaaer,asmaer,ecaer
+!f2py depend(ncol,nlay) swuflx,swdflx
+!f2py depend(ncol,nlay) swhr
+!f2py depend(ncol,nlay) swuflxc,swdflxc
+!f2py depend(ncol,nlay) swhrc
 
     !  Call the RRTMG_SW driver to compute radiative fluxes
     call rrtmg_sw(ncol    ,nlay    ,icld    ,iaer    , &

--- a/climlab_rrtmg/rrtmg_sw/Driver.f90
+++ b/climlab_rrtmg/rrtmg_sw/Driver.f90
@@ -125,12 +125,12 @@ subroutine climlab_rrtmg_sw &
     integer, parameter :: rb = selected_real_kind(12)
     integer(kind=im), intent(in) :: ncol            ! number of columns
     integer(kind=im), intent(in) :: nlay            ! number of model layers
-    integer(kind=im), intent(inout) :: icld            ! Cloud overlap method
+    integer(kind=im), intent(inout) :: icld         ! Cloud overlap method
                                                     !    0: Clear only
                                                     !    1: Random
                                                     !    2: Maximum/random
                                                     !    3: Maximum
-    integer(kind=im), intent(inout) :: iaer            ! Aerosol option flag
+    integer(kind=im), intent(inout) :: iaer         ! Aerosol option flag
                                                     !    0: No aerosol
                                                     !    6: ECMWF method
                                                     !    10:Input aerosol optical
@@ -151,7 +151,7 @@ subroutine climlab_rrtmg_sw &
     real(kind=rb), intent(in) :: asdif(ncol)        ! UV/vis surface albedo: diffuse rad
     real(kind=rb), intent(in) :: asdir(ncol)        ! Near-IR surface albedo: diffuse rad
     real(kind=rb), intent(in) :: coszen(ncol)       ! Cosine of solar zenith angle
-    real(kind=rb), intent(in) :: adjes(ncol)        ! Flux adjustment for Earth/Sun distance
+    real(kind=rb), intent(in) :: adjes(ncol)        ! Flux adjustment (Earth/Sun distance and/or zenith angle compensation)
     integer(kind=im), intent(in) :: dyofyr          ! Day of the year (used to get Earth/Sun
                                                     !  distance if adjflx not provided)
     real(kind=rb), intent(in) :: scon               ! Solar constant (W/m2)

--- a/climlab_rrtmg/tests/test_climlab_rrtmg.py
+++ b/climlab_rrtmg/tests/test_climlab_rrtmg.py
@@ -2,6 +2,17 @@ import pytest
 import numpy as np
 from climlab_rrtmg import rrtmg_lw, rrtmg_sw
 
+# nbndsw = int(rrtmg_sw.parrrsw.nbndsw)
+# naerec = int(rrtmg_sw.parrrsw.naerec)
+# ngptsw = int(rrtmg_sw.parrrsw.ngptsw)
+# nbndlw = int(rrtmg_lw.parrrtm.nbndlw)
+# ngptlw = int(rrtmg_lw.parrrtm.ngptlw)
+nbndsw = 14
+naerec  = 6
+ngptsw = 112
+nbndlw = 16
+ngptlw = 140
+
 # Specific heat at constant pressure
 cp = 1004.
 
@@ -70,8 +81,6 @@ reic = 0. * np.ones_like(play)  # Cloud ice particle effective size (microns)
 
 
 def test_rrtmg_lw_clearsky():
-    nbndlw = int(rrtmg_lw.parrrtm.nbndlw)
-    ngptlw = int(rrtmg_lw.parrrtm.ngptlw)
     #  Initialize absorption data
     rrtmg_lw.climlab_rrtmg_lw_ini(cp)
 
@@ -117,8 +126,6 @@ def test_rrtmg_lw_clearsky():
                      tauaer)
 
 def test_rrtmg_lw_mcica():
-    nbndlw = int(rrtmg_lw.parrrtm.nbndlw)
-    ngptlw = int(rrtmg_lw.parrrtm.ngptlw)
     #  Initialize absorption data
     rrtmg_lw.climlab_rrtmg_lw_ini(cp)
 
@@ -164,9 +171,6 @@ def test_rrtmg_lw_mcica():
 
 
 def test_rrtmg_sw_clearsky():
-    nbndsw = int(rrtmg_sw.parrrsw.nbndsw)
-    naerec = int(rrtmg_sw.parrrsw.naerec)
-    ngptsw = int(rrtmg_sw.parrrsw.ngptsw)
     #  Initialize absorption data
     rrtmg_sw.climlab_rrtmg_sw_ini(cp)
     #  Lots of RRTMG parameters
@@ -273,9 +277,6 @@ def test_rrtmg_sw_clearsky():
                 bndsolvar, indsolvar, solcycfrac)
 
 def test_rrtmg_sw_mcica():
-    nbndsw = int(rrtmg_sw.parrrsw.nbndsw)
-    naerec = int(rrtmg_sw.parrrsw.naerec)
-    ngptsw = int(rrtmg_sw.parrrsw.ngptsw)
     #  Initialize absorption data
     rrtmg_sw.climlab_rrtmg_sw_ini(cp)
     #  Lots of RRTMG parameters
@@ -368,9 +369,6 @@ def test_rrtmg_sw_multicol():
     n2ovmr_2d = np.tile(n2ovmr, [ncol, 1])
     o2vmr_2d = np.tile(o2vmr, [ncol, 1])
 
-    nbndsw = int(rrtmg_sw.parrrsw.nbndsw)
-    naerec = int(rrtmg_sw.parrrsw.naerec)
-    ngptsw = int(rrtmg_sw.parrrsw.ngptsw)
     #  Initialize absorption data
     rrtmg_sw.climlab_rrtmg_sw_ini(cp)
     #  Lots of RRTMG parameters

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,144 @@
+project('Fortran Wrapper', 'c', 
+  version : '0.1',
+  meson_version: '>=0.64.0',
+  default_options : ['warning_level=2'],
+)
+
+add_languages('fortran')
+# Add Fortran compiler flags globally (you already have this)
+add_project_arguments(
+    '-O2', '-fPIC', '-ftree-vectorize', '-fno-range-check', '-fvisibility=hidden', 
+    '-fstack-protector-strong', '-mtune=haswell', '-march=nocona', '-ffunction-sections', 
+    '-pipe', '-Wno-unused-variable', language: 'fortran'
+)
+
+# Fortran source files: sw
+rrtmg_sw_sources = files(
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/parkind.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/parrrsw.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_aer.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_cld.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_con.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg16.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg17.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg18.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg19.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg20.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg21.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg22.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg23.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg24.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg25.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg26.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg27.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg28.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_kg29.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_ncpar.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_ref.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_tbl.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_vsn.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/modules/rrsw_wvn.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/src/rrtmg_sw_k_g.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/src/mcica_random_numbers.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/src/mcica_subcol_gen_sw.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/src/rrtmg_sw_vrtqdr.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/src/rrtmg_sw_reftra.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/src/rrtmg_sw_taumol.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/src/rrtmg_sw_spcvmc.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/src/rrtmg_sw_setcoef.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/src/rrtmg_sw_init.f90',
+  'climlab_rrtmg/rrtmg_sw/rrtmg_sw_v4.0/gcm_model/src/rrtmg_sw_cldprmc.f90',
+  'climlab_rrtmg/rrtmg_sw/sourcemods/rrtmg_sw_rad.f90',
+  'climlab_rrtmg/rrtmg_sw/Driver.f90',
+)
+#unoptimized_src = ['rrtmg_sw_k_g.f90']
+
+# Fortran source files: lw
+rrtmg_lw_sources = files(
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/parkind.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/parrrtm.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_cld.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_con.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg01.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg02.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg03.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg04.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg05.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg06.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg07.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg08.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg09.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg10.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg11.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg12.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg13.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg14.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg15.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_kg16.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_ncpar.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_ref.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_tbl.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_vsn.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/modules/rrlw_wvn.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/src/rrtmg_lw_k_g.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/src/rrtmg_lw_taumol.f90',
+  'climlab_rrtmg/rrtmg_lw/sourcemods/rrtmg_lw_setcoef.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/src/rrtmg_lw_rtrnmc.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/src/rrtmg_lw_cldprmc.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/src/mcica_random_numbers.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/src/mcica_subcol_gen_lw.f90',
+  'climlab_rrtmg/rrtmg_lw/rrtmg_lw_v4.85/gcm_model/src/rrtmg_lw_init.f90',
+  'climlab_rrtmg/rrtmg_lw/sourcemods/rrtmg_lw_rad.f90',
+  'climlab_rrtmg/rrtmg_lw/Driver.f90',
+)
+#unoptimized_src = ['rrtmg_lw_k_g.f90']
+
+py_mod = import('python')
+py = py_mod.find_installation(pure: false)
+py_dep = py.dependency()
+
+incdir_numpy = run_command(py,
+  ['-c', 'import os; os.chdir(".."); import numpy; print(numpy.get_include())'],
+  check : true
+).stdout().strip()
+
+incdir_f2py = run_command(py,
+    ['-c', 'import os; os.chdir(".."); import numpy.f2py; print(numpy.f2py.get_include())'],
+    check : true
+).stdout().strip()
+
+inc_np = include_directories(incdir_numpy, incdir_f2py)
+
+rrtmg_sw_library = static_library(
+  'rrtmg_sw',
+  rrtmg_sw_sources,
+  include_directories: inc_np
+)
+
+py.extension_module('_rrtmg_sw',
+  sources: [
+    '_rrtmg_swmodule.c',
+    incdir_f2py / 'fortranobject.c'
+  ],
+  include_directories: inc_np,
+  link_with: rrtmg_sw_library,
+  dependencies: py_dep,
+  install: true
+)
+
+rrtmg_lw_library = static_library(
+  'rrtmg_lw',
+  rrtmg_lw_sources,
+  include_directories: inc_np
+)
+
+py.extension_module('_rrtmg_lw',
+  sources: [
+    '_rrtmg_lwmodule.c',
+    incdir_f2py / 'fortranobject.c'
+  ],
+  include_directories: inc_np,
+  link_with: rrtmg_lw_library,
+  dependencies: py_dep,
+  install: true
+)


### PR DESCRIPTION
was able to build using meson. 
rrtmg_sw.parrrsw, rrtmg_lw.parrrtm are no longer supported (they are used in the wrapper and climlab to get some specified integers in the fortran rrtmg code, but these are hard coded anyway). So some minor changes need to be done in parallel to the rrtmg_sw.py and rrtmg_lw.py files (first few lines).

For the sake of documentation, the build was done on:
GNU ld (GNU Binutils for Ubuntu) 2.38
GNU Fortran (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0

Building can be done with the following commands at the project root directory:
```
python -m numpy.f2py ./climlab_rrtmg/rrtmg_sw/Driver.f90 -m _rrtmg_sw --lower
python -m numpy.f2py ./climlab_rrtmg/rrtmg_lw/Driver.f90 -m _rrtmg_lw --lower
meson setup builddir
meson compile -C builddir
```